### PR TITLE
Add get_molecule

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     rayrender,
     magrittr,
     tibble,
-    PeriodicTable
+    PeriodicTable, 
+    httr
 LazyData: true
 RoxygenNote: 7.1.0

--- a/R/get_molecule.R
+++ b/R/get_molecule.R
@@ -1,0 +1,34 @@
+#' Get Molecule
+#'
+#' Loads the structure of a molecule by fetching an SDF file from Pubchem, which can be piped to generate_full_scene
+#'
+#' @param molecule A character variable of a compound name or a numeric variable of an official compound ID
+#'
+#' @return List giving the atom locations and the connections between atoms.
+#' @export
+#'
+#' @examples
+#' get_molecule("caffeine")
+#' get_molecule(5757) #estradiol (aka estrogen)
+#' get_molecule("aspirin")
+get_molecule = function(molecule) {
+  #molecule details
+  if (is.numeric(molecule)) {    #assume it is a CID
+    url <- paste0("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/", molecule, "/SDF")
+  } else if (is.character(molecule)) {    #assume it is a compound name
+    url <- paste0("https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/", molecule, "/SDF")
+  } else {
+    stop("Provide a quoted compound name (character) or an unquoted compound ID (numeric)")
+  }
+
+  status <- httr::GET(url) %>%
+    httr::status_code()
+
+  if (status == 200) {
+    molecule_sdf <-
+      raymolecule::read_sdf(url)
+  } else {
+    stop("Cannot find your compound. Check the compound name or compound ID (CID)")
+  }
+  return(molecule_sdf)
+}

--- a/README.Rmd
+++ b/README.Rmd
@@ -36,11 +36,12 @@ remotes::install_github("tylermorganwall/raymolecule")
 
 ## Examples
 
-`raymolecule` includes several example SDF files for the following molecules: "benzene", "buckyball", "caffeine", "capsaicin", "cinnemaldehyde", "geraniol", "luciferin", "morphine", "penicillin", "pfoa", "skatole", "tubocurarine_chloride". You can get the file path to these example files using the `get_example_molecule()` function. We pass this path to the `read_sdf()` file to parse the file and extract the atom coordinates and bond information in a list. The magrittr pipe is automatically imported in the package, so we will use it to pass the output of each function to the input of the next.
+`raymolecule` includes several example SDF files for the following molecules: "benzene", "buckyball", "caffeine", "capsaicin", "cinnemaldehyde", "geraniol", "luciferin", "morphine", "penicillin", "pfoa", "skatole", "tubocurarine_chloride". You can get the file path to these example files using the `get_example_molecule()` function. We pass this path to the `read_sdf()` file to parse the file and extract the atom coordinates and bond information in a list. `raymolecule` also includes the ability to fetch molecules from PubChem using the `get_molecule()` function. The magrittr pipe is automatically imported in the package, so we will use it to pass the output of each function to the input of the next.
 
 Here's the format of the data:
 
 ```{r}
+
 library(raymolecule)
 
 get_example_molecule("benzene") %>%
@@ -48,7 +49,17 @@ get_example_molecule("benzene") %>%
 
 ```
 
-We can then pass this list to the `generate_full_scene()`, `generate_atom_scene()`, or `generate_bond_scene()` functions to convert this representation to a rayrender scene. This can then be passed on the `render_model()` function, which will call rayrender's `render_scene()` function to render it. This function automatically ensures the molecule is centered and in frame, and sets up lighting, and can accept arguments to rotate the molecule. For more rendering options, see `rayrender::render_scene()`.
+Alternatively, you can fetch any molecule from [PubChem](https://pubchem.ncbi.nlm.nih.gov) by passing either the molecule name. You can also fetch a molecule using the official compound ID (CID), in case you have a specific molecule with a long name or unique isoform:  
+  
+```{r}
+
+get_molecule("estradiol")
+
+get_molecule(5757) #this is the CID for estradiol (aka estrogen)
+
+```
+
+We can then pass the list from `get_example_molecule() %>% read_sdf()` or from `get_molecule()` to the `generate_full_scene()`, `generate_atom_scene()`, or `generate_bond_scene()` functions to convert this representation to a rayrender scene. This can then be passed on the `render_model()` function, which will call rayrender's `render_scene()` function to render it. This function automatically ensures the molecule is centered and in frame, and sets up lighting, and can accept arguments to rotate the molecule. For more rendering options, see `rayrender::render_scene()`.
 
 
 ```{r}


### PR DESCRIPTION
Adds the ability to get SDF files from a compound name or compound ID, updates the readme, and adds httr as an import in the description file.

I updated the readme, but didn't re-knit it, as get_molecule() isn't in the package yet, so knit choked. 